### PR TITLE
track number of connected users and number of total users

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -7,6 +7,8 @@ bucket_settings = train_buckets(settings.startup["graftorio2-train-histogram-buc
 nth_tick = settings.startup["graftorio2-nth-tick"].value
 
 gauge_tick = prometheus.gauge("factorio_tick", "game tick")
+gauge_connected_player_count = prometheus.gauge("factorio_connected_player_count", "connected players")
+gauge_total_player_count = prometheus.gauge("factorio_total_player_count", "total registered players")
 
 gauge_item_production_input = prometheus.gauge("factorio_item_production_input", "items produced", {"force", "name"})
 gauge_item_production_output = prometheus.gauge("factorio_item_production_output", "items consumed", {"force", "name"})
@@ -45,11 +47,13 @@ script.on_init(function()
   end
 
   script.on_nth_tick(nth_tick, register_events)
+  script.on_event(defines.events.on_player_left_game, register_events)
   script.on_event(defines.events.on_train_changed_state, register_events_train)
 end)
 
 script.on_load(function()
   script.on_nth_tick(nth_tick, register_events)
+  script.on_event(defines.events.on_player_left_game, register_events)
   script.on_event(defines.events.on_train_changed_state, register_events_train)
 end)
 

--- a/control.lua
+++ b/control.lua
@@ -47,13 +47,25 @@ script.on_init(function()
   end
 
   script.on_nth_tick(nth_tick, register_events)
-  script.on_event(defines.events.on_player_left_game, register_events)
+
+  script.on_event(defines.events.on_player_joined_game, register_events_players)
+  script.on_event(defines.events.on_player_left_game, register_events_players)
+  script.on_event(defines.events.on_player_removed, register_events_players)
+  script.on_event(defines.events.on_player_kicked, register_events_players)
+  script.on_event(defines.events.on_player_banned, register_events_players)
+
   script.on_event(defines.events.on_train_changed_state, register_events_train)
 end)
 
 script.on_load(function()
   script.on_nth_tick(nth_tick, register_events)
-  script.on_event(defines.events.on_player_left_game, register_events)
+
+  script.on_event(defines.events.on_player_joined_game, register_events_players)
+  script.on_event(defines.events.on_player_left_game, register_events_players)
+  script.on_event(defines.events.on_player_removed, register_events_players)
+  script.on_event(defines.events.on_player_kicked, register_events_players)
+  script.on_event(defines.events.on_player_banned, register_events_players)
+
   script.on_event(defines.events.on_train_changed_state, register_events_train)
 end)
 

--- a/events.lua
+++ b/events.lua
@@ -1,7 +1,5 @@
 function register_events(event)
     gauge_tick:set(game.tick)
-    gauge_connected_player_count:set(#game.connected_players)
-    gauge_total_player_count:set(#game.players)
 
     for _, player in pairs(game.players) do
       stats = {
@@ -27,4 +25,9 @@ function register_events(event)
     end
 
     game.write_file("graftorio2/game.prom", prometheus.collect(), false)
+end
+
+function register_events_players(event)
+    gauge_connected_player_count:set(#game.connected_players)
+    gauge_total_player_count:set(#game.players)
 end

--- a/events.lua
+++ b/events.lua
@@ -1,5 +1,8 @@
 function register_events(event)
     gauge_tick:set(game.tick)
+    gauge_connected_player_count:set(#game.connected_players)
+    gauge_total_player_count:set(#game.players)
+
     for _, player in pairs(game.players) do
       stats = {
         {player.force.item_production_statistics, gauge_item_production_input, gauge_item_production_output},


### PR DESCRIPTION
adds a gauge for total players registered in the save and one for number of current connected players.
To account for the fact that factorio headless auto-pauses the game and stops increasing the tick count when the last player disconnects I've also made the collection run `on_player_left_game`

resolves #3