### PR TITLE
Fix YARM compatibility

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -50,7 +50,8 @@ gauge_logistic_network_items = prometheus.gauge("factorio_logistic_network_items
 
 script.on_init(function()
   if game.active_mods["YARM"] then
-      script.on_event(remote.call("YARM", "get_on_site_updated_event_id"), handleYARM)
+	global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
+    script.on_event(global.yarm_on_site_update_event_id, handleYARM)
   end
 
   script.on_nth_tick(nth_tick, register_events)
@@ -65,6 +66,10 @@ script.on_init(function()
 end)
 
 script.on_load(function()
+  if global.yarm_on_site_update_event_id then
+    script.on_event(global.yarm_on_site_update_event_id, handleYARM)
+  end
+
   script.on_nth_tick(nth_tick, register_events)
 
   script.on_event(defines.events.on_player_joined_game, register_events_players)
@@ -78,6 +83,7 @@ end)
 
 script.on_configuration_changed(function(event)
   if game.active_mods["YARM"] then
-      script.on_event(remote.call("YARM", "get_on_site_updated_event_id"), handleYARM)
+	global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
+    script.on_event(global.yarm_on_site_update_event_id, handleYARM)
   end
 end)

--- a/control.lua
+++ b/control.lua
@@ -50,7 +50,7 @@ gauge_logistic_network_items = prometheus.gauge("factorio_logistic_network_items
 
 script.on_init(function()
   if game.active_mods["YARM"] then
-	global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
+    global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
     script.on_event(global.yarm_on_site_update_event_id, handleYARM)
   end
 
@@ -83,7 +83,7 @@ end)
 
 script.on_configuration_changed(function(event)
   if game.active_mods["YARM"] then
-	global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
+    global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
     script.on_event(global.yarm_on_site_update_event_id, handleYARM)
   end
 end)


### PR DESCRIPTION
Yarm metrics only works when the game first start or the mods change. This is because on_load the event_id of the site update is not known. 

At runtime of on_load, we don't have the game object and `remote.call("YARM", "get_on_site_updated_event_id")` will also return nil.

Therefor I had the idea of a global variable for the event_id. It also treats as a toggle if yarm is installed or not in on_load.

Feedback is very welcome. Thanks for maintaning this mod 👍 