### PR TITLE
Add option to disable train stats #22

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -8,6 +8,7 @@ require("power")
 bucket_settings = train_buckets(settings.startup["graftorio2-train-histogram-buckets"].value)
 nth_tick = settings.startup["graftorio2-nth-tick"].value
 server_save = settings.startup["graftorio2-server-save"].value
+disable_train_stats = settings.startup["graftorio2-disable-train-stats"].value
 
 gauge_tick = prometheus.gauge("factorio_tick", "game tick")
 gauge_connected_player_count = prometheus.gauge("factorio_connected_player_count", "connected players")
@@ -73,8 +74,10 @@ script.on_init(function()
   script.on_event(defines.events.on_player_banned, register_events_players)
 
   -- train envents
-  script.on_event(defines.events.on_train_changed_state, register_events_train)
-
+  if not disable_train_stats then
+    script.on_event(defines.events.on_train_changed_state, register_events_train)
+  end
+  
   -- power events
   script.on_event(defines.events.on_built_entity, on_power_build)
   script.on_event(defines.events.on_robot_built_entity, on_power_build)
@@ -107,7 +110,9 @@ script.on_load(function()
   script.on_event(defines.events.on_player_banned, register_events_players)
 
   -- train events
-  script.on_event(defines.events.on_train_changed_state, register_events_train)
+  if not disable_train_stats then
+    script.on_event(defines.events.on_train_changed_state, register_events_train)
+  end
 
   -- power events
   script.on_event(defines.events.on_built_entity, on_power_build)

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -2,6 +2,7 @@
 graftorio2-train-histogram-buckets=Train histogram buckets
 graftorio2-nth-tick=Scheduler timer
 graftorio2-server-save=Save prom file on server only
+graftorio2-disable-train-stats=Disable train stats
 
 [mod-setting-description]
 graftorio2-train-histogram-buckets=Train trip times (in seconds) to categorize into groups.

--- a/settings.lua
+++ b/settings.lua
@@ -19,5 +19,12 @@ data:extend({
       setting_type = "startup",
       default_value = false,
       allow_blank = false
+  },
+  {
+    type = "bool-setting",
+    name = "graftorio2-disable-train-stats",
+    setting_type = "startup",
+    default_value = false,
+    allow_blank = false
   }
 })


### PR DESCRIPTION
Add option to disable train stats.

If a plant has frequent train arrivals and departures, game.prom will exceed 10MB, causing the game to lag significantly on a regular basis.