### PR TITLE
Improve train metrics setting

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -8,7 +8,6 @@ require("research")
 bucket_settings = train_buckets(settings.startup["graftorio2-train-histogram-buckets"].value)
 nth_tick = settings.startup["graftorio2-nth-tick"].value
 server_save = settings.startup["graftorio2-server-save"].value
-disable_train_stats = settings.startup["graftorio2-disable-train-stats"].value
 
 gauge_tick = prometheus.gauge("factorio_tick", "game tick")
 gauge_connected_player_count = prometheus.gauge("factorio_connected_player_count", "connected players")
@@ -140,7 +139,9 @@ script.on_init(function()
 	script.on_event(defines.events.on_player_kicked, register_events_players)
 	script.on_event(defines.events.on_player_banned, register_events_players)
 
+
 	-- train envents
+	disable_train_stats = settings.global["graftorio2-disable-train-stats"].value
 	if not disable_train_stats then
 		script.on_event(defines.events.on_train_changed_state, register_events_train)
 	end
@@ -176,6 +177,7 @@ script.on_load(function()
 	script.on_event(defines.events.on_player_banned, register_events_players)
 
 	-- train events
+	disable_train_stats = settings.global["graftorio2-disable-train-stats"].value
 	if not disable_train_stats then
 		script.on_event(defines.events.on_train_changed_state, register_events_train)
 	end

--- a/settings.lua
+++ b/settings.lua
@@ -23,8 +23,8 @@ data:extend({
 	{
 		type = "bool-setting",
 		name = "graftorio2-disable-train-stats",
-		setting_type = "startup",
-		default_value = false,
+		setting_type = "runtime-global",
+		default_value = true,
 		allow_blank = false,
 	},
 })


### PR DESCRIPTION
# Objective
- make train metrics a global setting rather than a startup setting
- disable by default

# Details
I found out that the train metrics from this mod were creating 100k+ active series on my Grafana Cloud account that would have soon cost me over $1k / mo. The server is a long-running project, so I was dismayed when the this disable feature was a "startup" setting rather than an "runtime-global". As far as I can tell, that meant I couldn't change the setting for my server after it was created. Setting it to "runtime-global" has seemingly allowed me to turn these metrics on and off as I please.

Lastly, in my opinion, these train metrics simply don't scale with Factorio and they should be disabled by default or reworked to bring the cardinality way down.