### PR TITLE
Add missing return in train_buckets

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -5,6 +5,7 @@ function train_buckets(bucket_settings)
 	for _, bucket in pairs(split(bucket_settings, ",")) do
 		table.insert(train_buckets, tonumber(bucket))
 	end
+	return train_buckets
 end
 
 local train_trips = {}


### PR DESCRIPTION
Before adding this return the train metrics were always exported with the default prometheus buckets.
At least on my machine, adding this return fixes it.