### PR TITLE
2.0 support, circuit network exporter

### DIFF
--- a/Metrics.md
+++ b/Metrics.md
@@ -88,12 +88,12 @@ Histogram bucket sizes can also be adjusted in the settings.
 
 | Name                                                      | Labels                                             | Description                                                          |
 |-----------------------------------------------------------|----------------------------------------------------|----------------------------------------------------------------------|
-| `factorio_logistic_network_all_construction_robots`       | force<br/>location (=surface)<br/>network          | Total number of construction robots in the network                   |
-| `factorio_logistic_network_available_construction_robots` | force<br/>location (=surface)<br/>network          | Number of construction robots in the network available for a new job |
-| `factorio_logistic_network_all_logistic_robots`           | force<br/>location (=surface)<br/>network          | Total number of construction robots in the network                   |
-| `factorio_logistic_network_available_logistic_robots`     | force<br/>location (=surface)<br/>network          | Number of construction robots in the network available for a new job |
-| `factorio_logistic_network_robot_limit`                   | force<br/>location (=surface)<br/>network          | Maximum number of robot the network can work with                    |
-| `factorio_logistic_network_items`                         | force<br/>location (=surface)<br/>network<br/>name | Number of item `name` in the network                                 |
+| `factorio_logistic_network_all_construction_robots`       | force<br/>surface<br/>network          | Total number of construction robots in the network                   |
+| `factorio_logistic_network_available_construction_robots` | force<br/>surface<br/>network          | Number of construction robots in the network available for a new job |
+| `factorio_logistic_network_all_logistic_robots`           | force<br/>surface<br/>network          | Total number of construction robots in the network                   |
+| `factorio_logistic_network_available_logistic_robots`     | force<br/>surface<br/>network          | Number of construction robots in the network available for a new job |
+| `factorio_logistic_network_robot_limit`                   | force<br/>surface<br/>network          | Maximum number of robot the network can work with                    |
+| `factorio_logistic_network_items`                         | force<br/>surface<br/>network<br/>name | Number of item `name` in the network                                 |
 
 
 ### Other

--- a/circuit-network.lua
+++ b/circuit-network.lua
@@ -1,0 +1,75 @@
+local data = {
+	inited = false,
+	combinators = {},
+}
+
+local function rescan()
+	data.combinators = {}
+	for _, player in pairs(game.players) do
+		for _, surface in pairs(game.surfaces) do
+			for _, combinator in
+				pairs(surface.find_entities_filtered({
+					force = player.force,
+					type = "constant-combinator",
+				}))
+			do
+				data.combinators[combinator.unit_number] = combinator
+			end
+		end
+	end
+	data.inited = true
+end
+
+function on_circuit_network_build(event)
+	local entity = event.entity or event.created_entity
+	if entity and entity.name == "constant-combinator" then
+		data.inited = false
+	end
+end
+
+function on_circuit_network_destroy(event)
+	local entity = event.entity
+	if entity.name == "constant-combinator" then
+		data.inited = false
+	end
+end
+
+function on_circuit_network_init()
+	data.inited = false
+end
+
+function on_circuit_network_load()
+	data.inited = false
+end
+
+function on_circuit_network_tick(event)
+	if event.tick then
+		if not data.inited then
+			rescan()
+		end
+
+		gauge_circuit_network_monitored:reset()
+		gauge_circuit_network_signal:reset()
+		local seen = {}
+		for _, combinator in pairs(data.combinators) do
+			for _, wire_type in pairs({ defines.wire_type.red, defines.wire_type.green }) do
+				local network = combinator.get_circuit_network(wire_type)
+				if network ~= nil and seen[network.network_id] == nil and network.signals ~= nil then
+					seen[network.network_id] = true
+					gauge_circuit_network_monitored:set(
+						1,
+						{ combinator.force.name, combinator.surface.name, tostring(network.network_id) }
+					)
+					for _, signal in pairs(network.signals) do
+						gauge_circuit_network_signal:set(signal.count, {
+							combinator.force.name,
+							combinator.surface.name,
+							tostring(network.network_id),
+							signal.signal.name,
+						})
+					end
+				end
+			end
+		end
+	end
+end

--- a/circuit-network.lua
+++ b/circuit-network.lua
@@ -54,17 +54,18 @@ function on_circuit_network_tick(event)
 		for _, combinator in pairs(data.combinators) do
 			for _, wire_type in pairs({ defines.wire_type.red, defines.wire_type.green }) do
 				local network = combinator.get_circuit_network(wire_type)
+				local network_id = tostring(network.network_id)
 				if network ~= nil and seen[network.network_id] == nil and network.signals ~= nil then
 					seen[network.network_id] = true
 					gauge_circuit_network_monitored:set(
 						1,
-						{ combinator.force.name, combinator.surface.name, tostring(network.network_id) }
+						{ combinator.force.name, combinator.surface.name, network_id }
 					)
 					for _, signal in pairs(network.signals) do
 						gauge_circuit_network_signal:set(signal.count, {
 							combinator.force.name,
 							combinator.surface.name,
-							tostring(network.network_id),
+							network_id,
 							signal.signal.name,
 						})
 					end

--- a/circuit-network.lua
+++ b/circuit-network.lua
@@ -21,7 +21,7 @@ local function rescan()
 end
 
 function on_circuit_network_build(event)
-	local entity = event.entity or event.created_entity
+	local entity = event.entity
 	if entity and entity.name == "constant-combinator" then
 		data.inited = false
 	end
@@ -52,21 +52,22 @@ function on_circuit_network_tick(event)
 		gauge_circuit_network_signal:reset()
 		local seen = {}
 		for _, combinator in pairs(data.combinators) do
-			for _, wire_type in pairs({ defines.wire_type.red, defines.wire_type.green }) do
+			for _, wire_type in pairs({ defines.wire_connector_id.circuit_red, defines.wire_connector_id.circuit_green }) do
 				local network = combinator.get_circuit_network(wire_type)
-				local network_id = tostring(network.network_id)
 				if network ~= nil and seen[network.network_id] == nil and network.signals ~= nil then
 					seen[network.network_id] = true
+					local network_id = tostring(network.network_id)
 					gauge_circuit_network_monitored:set(
 						1,
 						{ combinator.force.name, combinator.surface.name, network_id }
 					)
-					for _, signal in pairs(network.signals) do
+					for _, signal in ipairs(network.signals) do
 						gauge_circuit_network_signal:set(signal.count, {
 							combinator.force.name,
 							combinator.surface.name,
 							network_id,
 							signal.signal.name,
+							signal.signal.quality,
 						})
 					end
 				end

--- a/control.lua
+++ b/control.lua
@@ -119,6 +119,12 @@ gauge_logistic_network_items = prometheus.gauge(
 	{ "force", "location", "network", "name" }
 )
 
+gauge_circuit_network_signal = prometheus.gauge(
+	"factorio_circuit_network_signal",
+	"the value of a signal in a circuit network",
+	{ "force", "location", "network", "name" }
+)
+
 gauge_power_production_input =
 	prometheus.gauge("factorio_power_production_input", "power produced", { "force", "name", "network", "surface" })
 gauge_power_production_output =

--- a/control.lua
+++ b/control.lua
@@ -4,6 +4,7 @@ require("yarm")
 require("events")
 require("power")
 require("research")
+require("circuit-network")
 
 bucket_settings = train_buckets(settings.startup["graftorio2-train-histogram-buckets"].value)
 nth_tick = settings.startup["graftorio2-nth-tick"].value
@@ -125,6 +126,12 @@ gauge_circuit_network_signal = prometheus.gauge(
 	{ "force", "location", "network", "name" }
 )
 
+gauge_circuit_network_monitored = prometheus.gauge(
+	"factorio_circuit_network_monitored",
+	"whether a circuit network with given ID is being monitored",
+	{ "force", "location", "network" }
+)
+
 gauge_power_production_input =
 	prometheus.gauge("factorio_power_production_input", "power produced", { "force", "name", "network", "surface" })
 gauge_power_production_output =
@@ -137,6 +144,7 @@ script.on_init(function()
 	end
 
 	on_power_init()
+	on_circuit_network_init()
 
 	script.on_nth_tick(nth_tick, register_events)
 
@@ -162,6 +170,15 @@ script.on_init(function()
 
 	-- research events
 	script.on_event(defines.events.on_research_finished, on_research_finished)
+
+	-- circuit-network
+	script.on_event(defines.events.on_built_entity, on_circuit_network_build)
+	script.on_event(defines.events.on_robot_built_entity, on_circuit_network_build)
+	script.on_event(defines.events.script_raised_built, on_circuit_network_build)
+	script.on_event(defines.events.on_player_mined_entity, on_circuit_network_destroy)
+	script.on_event(defines.events.on_robot_mined_entity, on_circuit_network_destroy)
+	script.on_event(defines.events.on_entity_died, on_circuit_network_destroy)
+	script.on_event(defines.events.script_raised_destroy, on_circuit_network_destroy)
 end)
 
 script.on_load(function()
@@ -172,6 +189,7 @@ script.on_load(function()
 	end
 
 	on_power_load()
+	on_circuit_network_load()
 
 	script.on_nth_tick(nth_tick, register_events)
 
@@ -197,6 +215,15 @@ script.on_load(function()
 
 	-- research events
 	script.on_event(defines.events.on_research_finished, on_research_finished)
+
+	-- circuit-network
+	script.on_event(defines.events.on_built_entity, on_circuit_network_build)
+	script.on_event(defines.events.on_robot_built_entity, on_circuit_network_build)
+	script.on_event(defines.events.script_raised_built, on_circuit_network_build)
+	script.on_event(defines.events.on_player_mined_entity, on_circuit_network_destroy)
+	script.on_event(defines.events.on_robot_mined_entity, on_circuit_network_destroy)
+	script.on_event(defines.events.on_entity_died, on_circuit_network_destroy)
+	script.on_event(defines.events.script_raised_destroy, on_circuit_network_destroy)
 end)
 
 script.on_configuration_changed(function(event)

--- a/control.lua
+++ b/control.lua
@@ -18,34 +18,34 @@ gauge_total_player_count = prometheus.gauge("factorio_total_player_count", "tota
 gauge_seed = prometheus.gauge("factorio_seed", "seed", { "surface" })
 gauge_mods = prometheus.gauge("factorio_mods", "mods", { "name", "version" })
 
-gauge_item_production_input = prometheus.gauge("factorio_item_production_input", "items produced", { "force", "name" })
+gauge_item_production_input = prometheus.gauge("factorio_item_production_input", "items produced", { "force", "name", "surface" })
 gauge_item_production_output =
-	prometheus.gauge("factorio_item_production_output", "items consumed", { "force", "name" })
+	prometheus.gauge("factorio_item_production_output", "items consumed", { "force", "name", "surface" })
 
 gauge_fluid_production_input =
-	prometheus.gauge("factorio_fluid_production_input", "fluids produced", { "force", "name" })
+	prometheus.gauge("factorio_fluid_production_input", "fluids produced", { "force", "name", "surface" })
 gauge_fluid_production_output =
-	prometheus.gauge("factorio_fluid_production_output", "fluids consumed", { "force", "name" })
+	prometheus.gauge("factorio_fluid_production_output", "fluids consumed", { "force", "name", "surface" })
 
-gauge_kill_count_input = prometheus.gauge("factorio_kill_count_input", "kills", { "force", "name" })
-gauge_kill_count_output = prometheus.gauge("factorio_kill_count_output", "losses", { "force", "name" })
+gauge_kill_count_input = prometheus.gauge("factorio_kill_count_input", "kills", { "force", "name", "surface" })
+gauge_kill_count_output = prometheus.gauge("factorio_kill_count_output", "losses", { "force", "name", "surface" })
 
 gauge_entity_build_count_input =
-	prometheus.gauge("factorio_entity_build_count_input", "entities placed", { "force", "name" })
+	prometheus.gauge("factorio_entity_build_count_input", "entities placed", { "force", "name", "surface" })
 gauge_entity_build_count_output =
-	prometheus.gauge("factorio_entity_build_count_output", "entities removed", { "force", "name" })
+	prometheus.gauge("factorio_entity_build_count_output", "entities removed", { "force", "name", "surface" })
 
 gauge_pollution_production_input =
-	prometheus.gauge("factorio_pollution_production_input", "pollutions produced", { "force", "name" })
+	prometheus.gauge("factorio_pollution_production_input", "pollutions produced", { "name", "surface" })
 gauge_pollution_production_output =
-	prometheus.gauge("factorio_pollution_production_output", "pollutions consumed", { "force", "name" })
+	prometheus.gauge("factorio_pollution_production_output", "pollutions consumed", { "name", "surface" })
 
-gauge_evolution = prometheus.gauge("factorio_evolution", "evolution", { "force", "type" })
+gauge_evolution = prometheus.gauge("factorio_evolution", "evolution", { "force", "type", "surface" })
 
 gauge_research_queue = prometheus.gauge("factorio_research_queue", "research", { "force", "name", "level", "index" })
 
 gauge_items_launched =
-	prometheus.gauge("factorio_items_launched_total", "items launched in rockets", { "force", "name" })
+	prometheus.gauge("factorio_items_launched_total", "items launched in rockets", { "force", "name", "quality" })
 
 gauge_yarm_site_amount =
 	prometheus.gauge("factorio_yarm_site_amount", "YARM - site amount remaining", { "force", "name", "type" })
@@ -89,47 +89,47 @@ histogram_train_arrival_time =
 gauge_logistic_network_all_construction_robots = prometheus.gauge(
 	"factorio_logistic_network_all_construction_robots",
 	"the total number of construction robots in the network (idle and active + in roboports)",
-	{ "force", "location", "network" }
+	{ "force", "surface", "network" }
 )
 gauge_logistic_network_available_construction_robots = prometheus.gauge(
 	"factorio_logistic_network_available_construction_robots",
 	"the number of construction robots available for a job",
-	{ "force", "location", "network" }
+	{ "force", "surface", "network" }
 )
 
 gauge_logistic_network_all_logistic_robots = prometheus.gauge(
 	"factorio_logistic_network_all_logistic_robots",
 	"the total number of logistic robots in the network (idle and active + in roboports)",
-	{ "force", "location", "network" }
+	{ "force", "surface", "network" }
 )
 gauge_logistic_network_available_logistic_robots = prometheus.gauge(
 	"factorio_logistic_network_available_logistic_robots",
 	"the number of logistic robots available for a job",
-	{ "force", "location", "network" }
+	{ "force", "surface", "network" }
 )
 
 gauge_logistic_network_robot_limit = prometheus.gauge(
 	"factorio_logistic_network_robot_limit",
 	"the maximum number of robots the network can work with",
-	{ "force", "location", "network" }
+	{ "force", "surface", "network" }
 )
 
 gauge_logistic_network_items = prometheus.gauge(
 	"factorio_logistic_network_items",
 	"the number of items in a logistic network",
-	{ "force", "location", "network", "name" }
+	{ "force", "surface", "network", "name", "quality" }
 )
 
 gauge_circuit_network_signal = prometheus.gauge(
 	"factorio_circuit_network_signal",
 	"the value of a signal in a circuit network",
-	{ "force", "location", "network", "name" }
+	{ "force", "surface", "network", "name" }
 )
 
 gauge_circuit_network_monitored = prometheus.gauge(
 	"factorio_circuit_network_monitored",
 	"whether a circuit network with given ID is being monitored",
-	{ "force", "location", "network" }
+	{ "force", "surface", "network" }
 )
 
 gauge_power_production_input =
@@ -138,9 +138,9 @@ gauge_power_production_output =
 	prometheus.gauge("factorio_power_production_output", "power consumed", { "force", "name", "network", "surface" })
 
 script.on_init(function()
-	if game.active_mods["YARM"] then
-		global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
-		script.on_event(global.yarm_on_site_update_event_id, handleYARM)
+	if script.active_mods["YARM"] then
+		storage.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
+		script.on_event(storage.yarm_on_site_update_event_id, handleYARM)
 	end
 
 	on_power_init()
@@ -182,9 +182,9 @@ script.on_init(function()
 end)
 
 script.on_load(function()
-	if global.yarm_on_site_update_event_id then
-		if script.get_event_handler(global.yarm_on_site_update_event_id) then
-			script.on_event(global.yarm_on_site_update_event_id, handleYARM)
+	if storage.yarm_on_site_update_event_id then
+		if script.get_event_handler(storage.yarm_on_site_update_event_id) then
+			script.on_event(storage.yarm_on_site_update_event_id, handleYARM)
 		end
 	end
 
@@ -227,8 +227,8 @@ script.on_load(function()
 end)
 
 script.on_configuration_changed(function(event)
-	if game.active_mods["YARM"] then
-		global.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
-		script.on_event(global.yarm_on_site_update_event_id, handleYARM)
+	if script.active_mods["YARM"] then
+		storage.yarm_on_site_update_event_id = remote.call("YARM", "get_on_site_updated_event_id")
+		script.on_event(storage.yarm_on_site_update_event_id, handleYARM)
 	end
 end)

--- a/control.lua
+++ b/control.lua
@@ -123,7 +123,7 @@ gauge_logistic_network_items = prometheus.gauge(
 gauge_circuit_network_signal = prometheus.gauge(
 	"factorio_circuit_network_signal",
 	"the value of a signal in a circuit network",
-	{ "force", "surface", "network", "name" }
+	{ "force", "surface", "network", "name", "quality" }
 )
 
 gauge_circuit_network_monitored = prometheus.gauge(
@@ -174,9 +174,11 @@ script.on_init(function()
 	-- circuit-network
 	script.on_event(defines.events.on_built_entity, on_circuit_network_build)
 	script.on_event(defines.events.on_robot_built_entity, on_circuit_network_build)
+	script.on_event(defines.events.on_space_platform_built_entity, on_circuit_network_build)
 	script.on_event(defines.events.script_raised_built, on_circuit_network_build)
 	script.on_event(defines.events.on_player_mined_entity, on_circuit_network_destroy)
 	script.on_event(defines.events.on_robot_mined_entity, on_circuit_network_destroy)
+	script.on_event(defines.events.on_space_platform_mined_entity, on_circuit_network_destroy)
 	script.on_event(defines.events.on_entity_died, on_circuit_network_destroy)
 	script.on_event(defines.events.script_raised_destroy, on_circuit_network_destroy)
 end)

--- a/events.lua
+++ b/events.lua
@@ -92,7 +92,7 @@ function register_events(event)
 			do
 				for _, wire_type in pairs({ defines.wire_type.red, defines.wire_type.green }) do
 					local network = combinator.get_circuit_network(wire_type)
-					if network ~= nil and seen[network.network_id] == nil then
+					if network ~= nil and seen[network.network_id] == nil and network.signals ~= nil then
 						seen[network.network_id] = true
 						for _, signal in pairs(network.signals) do
 							gauge_circuit_network_signal:set(

--- a/events.lua
+++ b/events.lua
@@ -84,6 +84,27 @@ function register_events(event)
 			end
 		end
 
+		gauge_circuit_network_signal:reset()
+		local seen = {}
+		for _, surface in pairs(game.surfaces) do
+			for _, combinator in
+				pairs(surface.find_entities_filtered({ force = player.force, type = "constant-combinator" }))
+			do
+				for _, wire_type in pairs({ defines.wire_type.red, defines.wire_type.green }) do
+					local network = combinator.get_circuit_network(wire_type)
+					if network ~= nil and seen[network.network_id] == nil then
+						seen[network.network_id] = true
+						for _, signal in pairs(network.signals) do
+							gauge_circuit_network_signal:set(
+								signal.count,
+								{ player.force.name, surface.name, tostring(network.network_id), signal.signal.name }
+							)
+						end
+					end
+				end
+			end
+		end
+
 		-- research tick handler
 		on_research_tick(player, event)
 	end

--- a/events.lua
+++ b/events.lua
@@ -84,33 +84,15 @@ function register_events(event)
 			end
 		end
 
-		gauge_circuit_network_signal:reset()
-		local seen = {}
-		for _, surface in pairs(game.surfaces) do
-			for _, combinator in
-				pairs(surface.find_entities_filtered({ force = player.force, type = "constant-combinator" }))
-			do
-				for _, wire_type in pairs({ defines.wire_type.red, defines.wire_type.green }) do
-					local network = combinator.get_circuit_network(wire_type)
-					if network ~= nil and seen[network.network_id] == nil and network.signals ~= nil then
-						seen[network.network_id] = true
-						for _, signal in pairs(network.signals) do
-							gauge_circuit_network_signal:set(
-								signal.count,
-								{ player.force.name, surface.name, tostring(network.network_id), signal.signal.name }
-							)
-						end
-					end
-				end
-			end
-		end
-
 		-- research tick handler
 		on_research_tick(player, event)
 	end
 
 	-- power tick handler
 	on_power_tick(event)
+
+	-- circuit network tick handler
+	on_circuit_network_tick(event)
 
 	if server_save then
 		game.write_file("graftorio2/game.prom", prometheus.collect(), false, 0)

--- a/events.lua
+++ b/events.lua
@@ -5,50 +5,57 @@ function register_events(event)
 		gauge_seed:set(surface.map_gen_settings.seed, { surface.name })
 	end
 
-	for name, version in pairs(game.active_mods) do
+	for name, version in pairs(script.active_mods) do
 		gauge_mods:set(1, { name, version })
 	end
 
+	for _, surface in pairs(game.surfaces) do
+		local stats = game.get_pollution_statistics(surface)
+		for name, n in pairs(stats.input_counts) do
+			gauge_pollution_production_input:set(n, { name, surface.name })
+		end
+		for name, n in pairs(stats.output_counts) do
+			gauge_pollution_production_output:set(n, { name, surface.name })
+		end
+	end
+
 	for _, player in pairs(game.players) do
-		stats = {
-			{ player.force.item_production_statistics, gauge_item_production_input, gauge_item_production_output },
-			{ player.force.fluid_production_statistics, gauge_fluid_production_input, gauge_fluid_production_output },
-			{ player.force.kill_count_statistics, gauge_kill_count_input, gauge_kill_count_output },
-			{
-				player.force.entity_build_count_statistics,
-				gauge_entity_build_count_input,
-				gauge_entity_build_count_output,
-			},
-			{
-				game.pollution_statistics,
-				gauge_pollution_production_input,
-				gauge_pollution_production_output,
-			},
-		}
+		for _, surface in pairs(game.surfaces) do
+			local stats = {
+				{ player.force.get_item_production_statistics(surface), gauge_item_production_input, gauge_item_production_output },
+				{ player.force.get_fluid_production_statistics(surface), gauge_fluid_production_input, gauge_fluid_production_output },
+				{ player.force.get_kill_count_statistics(surface), gauge_kill_count_input, gauge_kill_count_output },
+				{
+					player.force.get_entity_build_count_statistics(surface),
+					gauge_entity_build_count_input,
+					gauge_entity_build_count_output,
+				},
+			}
 
-		for _, stat in pairs(stats) do
-			for name, n in pairs(stat[1].input_counts) do
-				stat[2]:set(n, { player.force.name, name })
+			for _, stat in pairs(stats) do
+				for name, n in pairs(stat[1].input_counts) do
+					stat[2]:set(n, { player.force.name, name, surface.name })
+				end
+
+				for name, n in pairs(stat[1].output_counts) do
+					stat[3]:set(n, { player.force.name, name, surface.name })
+				end
 			end
 
-			for name, n in pairs(stat[1].output_counts) do
-				stat[3]:set(n, { player.force.name, name })
+			local evolution = {
+				{ player.force.get_evolution_factor(surface), "total" },
+				{ player.force.get_evolution_factor_by_pollution(surface), "by_pollution" },
+				{ player.force.get_evolution_factor_by_time(surface), "by_time" },
+				{ player.force.get_evolution_factor_by_killing_spawners(surface), "by_killing_spawners" },
+			}
+
+			for _, stat in pairs(evolution) do
+				gauge_evolution:set(stat[1], { player.force.name, stat[2], surface.name })
 			end
-		end
 
-		evolution = {
-			{ player.force.evolution_factor, "total" },
-			{ player.force.evolution_factor_by_pollution, "by_pollution" },
-			{ player.force.evolution_factor_by_time, "by_time" },
-			{ player.force.evolution_factor_by_killing_spawners, "by_killing_spawners" },
-		}
-
-		for _, stat in pairs(evolution) do
-			gauge_evolution:set(stat[1], { player.force.name, stat[2] })
-		end
-
-		for name, n in pairs(player.force.items_launched) do
-			gauge_items_launched:set(n, { player.force.name, name })
+			for _, entry in ipairs(player.force.items_launched) do
+				gauge_items_launched:set(entry.count, { player.force.name, entry.name, entry.quality })
+			end
 		end
 
 		gauge_logistic_network_all_logistic_robots:reset()
@@ -57,28 +64,29 @@ function register_events(event)
 		gauge_logistic_network_available_construction_robots:reset()
 		gauge_logistic_network_robot_limit:reset()
 		gauge_logistic_network_items:reset()
-		for name, n in pairs(player.force.logistic_networks) do
-			for i in ipairs(n) do
+		for surface, networks in pairs(player.force.logistic_networks) do
+			for _, network in ipairs(networks) do
+				local network_id = tostring(network.network_id)
 				gauge_logistic_network_all_logistic_robots:set(
-					n[i].all_logistic_robots,
-					{ player.force.name, name, tostring(i) }
+					network.all_logistic_robots,
+					{ player.force.name, surface, network_id }
 				)
 				gauge_logistic_network_available_logistic_robots:set(
-					n[i].available_logistic_robots,
-					{ player.force.name, name, tostring(i) }
+					network.available_logistic_robots,
+					{ player.force.name, surface, network_id }
 				)
 				gauge_logistic_network_all_construction_robots:set(
-					n[i].all_construction_robots,
-					{ player.force.name, name, tostring(i) }
+					network.all_construction_robots,
+					{ player.force.name, surface, network_id }
 				)
 				gauge_logistic_network_available_construction_robots:set(
-					n[i].available_construction_robots,
-					{ player.force.name, name, tostring(i) }
+					network.available_construction_robots,
+					{ player.force.name, surface, network_id }
 				)
-				gauge_logistic_network_robot_limit:set(n[i].robot_limit, { player.force.name, name, tostring(i) })
-				if n[i].get_contents() ~= nil then
-					for item, l in pairs(n[i].get_contents()) do
-						gauge_logistic_network_items:set(l, { player.force.name, name, tostring(i), item })
+				gauge_logistic_network_robot_limit:set(network.robot_limit, { player.force.name, surface, network_id })
+				if network.get_contents() ~= nil then
+					for _, entry in ipairs(network.get_contents()) do
+						gauge_logistic_network_items:set(entry.count, { player.force.name, surface, network_id, entry.name, entry.quality })
 					end
 				end
 			end
@@ -95,9 +103,9 @@ function register_events(event)
 	on_circuit_network_tick(event)
 
 	if server_save then
-		game.write_file("graftorio2/game.prom", prometheus.collect(), false, 0)
+		helpers.write_file("graftorio2/game.prom", prometheus.collect(), false, 0)
 	else
-		game.write_file("graftorio2/game.prom", prometheus.collect(), false)
+		helpers.write_file("graftorio2/game.prom", prometheus.collect(), false)
 	end
 end
 

--- a/events.lua
+++ b/events.lua
@@ -54,7 +54,7 @@ function register_events(event)
 			end
 
 			for _, entry in ipairs(player.force.items_launched) do
-				gauge_items_launched:set(entry.count, { player.force.name, entry.name, entry.quality })
+				gauge_items_launched:set(entry.count, { player.force.name, entry.name, entry.quality }) -- this one seems broken :(
 			end
 		end
 

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
-  "name": "graftorio2",
-  "version": "0.0.20",
-  "title": "graftorio2",
+  "name": "graftorio2-mvolfik",
+  "version": "0.0.1",
+  "title": "graftorio2 - mvolfik patch",
   "author": "remijouannet",
   "description": "visualize metrics from your factorio game in grafana",
   "homepage": "https://github.com/remijouannet/graftorio2",
   "dependencies": ["? YARM >= 0.8.207"],
-  "factorio_version": "1.1"
+  "factorio_version": "2.0"
 }

--- a/research.lua
+++ b/research.lua
@@ -1,7 +1,7 @@
 function on_research_finished(event)
 	local research = event.research
-	if not global.last_research then
-		global.last_research = {}
+	if not storage.last_research then
+		storage.last_research = {}
 	end
 
 	local level = research.level
@@ -10,7 +10,7 @@ function on_research_finished(event)
 		level = level - 1
 	end
 
-	global.last_research[research.force.name] = {
+	storage.last_research[research.force.name] = {
 		researched = 1,
 		name = research.name,
 		level = level,
@@ -21,7 +21,7 @@ function on_research_tick(player, event)
 	if event.tick then
 		gauge_research_queue:reset()
 
-		local researched_queue = global.last_research and global.last_research["player.force.name"] or false
+		local researched_queue = storage.last_research and storage.last_research["player.force.name"] or false
 		if researched_queue then
 			gauge_research_queue:set(
 				researched_queue.researched and 1 or 0,

--- a/settings.lua
+++ b/settings.lua
@@ -10,14 +10,14 @@ data:extend({
 		type = "int-setting",
 		name = "graftorio2-nth-tick",
 		setting_type = "startup",
-		default_value = "300",
+		default_value = 300,
 		allow_blank = false,
 	},
 	{
 		type = "bool-setting",
 		name = "graftorio2-server-save",
 		setting_type = "startup",
-		default_value = false,
+		default_value = true,
 		allow_blank = false,
 	},
 	{


### PR DESCRIPTION
**Update**: Seems like @seiggy published a fork where my patches are applied (and a few more fixes). I suppose it's easiest to install and use that, as it's published to the mod repository: https://mods.factorio.com/mod/graftorio2-seiggy / https://github.com/seiggy/graftorio2

---

fixes #29 
fixes #40 

this will need some cleanup before merging:
- document the added circuit network support: constant combinator acts as an "exporter" - only networks that are connected to some constant combinator will be in the metrics
- update the grafana dashboards for the changed labels (if it is used, I didn't check yet)
  - I would also prefer to rename some weird names, like input/output to production/consumption | kills/losses etc
- revert the changes made to info.json

However, if anyone wants to play with this dirty patch on 2.0/Space Age, here you go:
~~[graftorio2-mvolfik_0.0.1.zip](https://github.com/user-attachments/files/17514039/graftorio2-mvolfik_0.0.1.zip)~~ d6a3ac8
~~[graftorio2-mvolfik_0.0.1.zip](https://github.com/user-attachments/files/17517475/graftorio2-mvolfik_0.0.1.zip) fixed build, no code changes in the repo~~ (I'm keeping the files for historical reasons, but see the update at the top)

Note that this is a "new" mod, not a version of graftorio(2). You will need to remove the original graftorio(2) mod.